### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,8 @@ jobs:
     - name: Test with pytest
       run: |
         python -m pytest --cov=. --cov-report=lcov
-        lcov --output-file coverage.cpp --capture --directory .
-        lcov --output-file coverage.cpp --extract coverage.cpp "*"
+        lcov --ignore-errors mismatch,unused --output-file coverage.cpp --capture --directory .
+        lcov --ignore-errors unused --output-file coverage.cpp --extract coverage.cpp "*"
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
       with:


### PR DESCRIPTION
from @claude 

> The `coverage` job installs `lcov` from Ubuntu's apt repo. When that package upgraded to [lcov 2.0](https://github.com/linux-test-project/lcov/releases/tag/v2.0), one of its headline changes was "improved error checking and error management" — including promoting line-number mismatches to fatal errors. Under lcov 1.x these were silent or warnings, so identical source/CI configs that passed for months suddenly hard-fail. The mismatch report itself even points at the new flag: *"use geninfo --ignore-errors mismatch ... to bypass this error."*
> 
> In our case `geninfo` flags `PyInit_systematics` at `systematics_bindings.cpp:180` (declared end line 180, observed end line 841). That gap is just pybind11's `PYBIND11_MODULE` macro expanding into a much larger function body — nothing in the bindings is actually wrong. The fix is to pass `--ignore-errors mismatch` to the `lcov --capture` step. Background discussion: [linux-test-project/lcov#209](https://github.com/linux-test-project/lcov/issues/209) and [#341](https://github.com/linux-test-project/lcov/issues/341).